### PR TITLE
chore: refactor to individual commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -31,40 +30,31 @@ var (
 	cfgFile string
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "btlr",
-	Short: "btlr is a cli to make it easy to execute commands reproducibly.",
-	Long:  `btlr is a cli to make it easy to execute commands reproducibly.`,
+func NewCommand() *cobra.Command {
+	cobra.OnInitialize(initConfig)
+
+	c := &cobra.Command{
+		Use:   "btlr",
+		Short: "btlr is a cli to make it easy to execute commands reproducibly.",
+		Long:  `btlr is a cli to make it easy to execute commands reproducibly.`,
+	}
+
+	c.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.btlr.yaml)")
+
+	registerRunCommand(c)
+	return c
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := NewCommand().Execute(); err != nil {
 		exit := 1
 		if terr, ok := err.(*exitError); ok {
 			exit = terr.Code
 		}
-		if exit != FailedCmdExitCode {
-			_, _ = fmt.Fprintf(stderr, "%s\n", err)
-		}
 		os.Exit(exit)
 	}
-}
-
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.btlr.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,13 +30,14 @@ var (
 	cfgFile string
 )
 
+// NewCommand returns a Command object representing an invocation of the btlr.
 func NewCommand() *cobra.Command {
 	cobra.OnInitialize(initConfig)
 
 	c := &cobra.Command{
 		Use:   "btlr",
 		Short: "btlr is a cli to make it easy to execute commands reproducibly.",
-		Long:  `btlr is a cli to make it easy to execute commands reproducibly.`,
+		Long:  "btlr is a cli to make it easy to execute commands reproducibly.",
 	}
 
 	c.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.btlr.yaml)")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -57,7 +57,7 @@ func TestRun(t *testing.T) {
 		rmCmd = "rm"
 	}
 
-	output, _ := ExecCmd(rootCmd, "run", filepath.Join(dir, "**", "*.txt"), rmCmd, "foo.txt")
+	output, _ := ExecCmd(NewCommand(), "run", filepath.Join(dir, "**", "*.txt"), rmCmd, "foo.txt")
 	outcomes := []struct {
 		contains string
 		want     bool
@@ -106,7 +106,7 @@ func TestMultiTest(t *testing.T) {
 		rmCmd = "rm"
 	}
 
-	output, _ := ExecCmd(rootCmd, "run", filepath.Join(dir, "foo", ""), filepath.Join(dir, "bar", ""), "--", rmCmd, "foo.txt")
+	output, _ := ExecCmd(NewCommand(), "run", filepath.Join(dir, "foo", ""), filepath.Join(dir, "bar", ""), "--", rmCmd, "foo.txt")
 	outcomes := []struct {
 		contains string
 		want     bool
@@ -167,7 +167,7 @@ func TestGitDiff(t *testing.T) {
 		rmCmd = "rm"
 	}
 
-	output, err := ExecCmd(rootCmd, "run", "--git-diff=main .", filepath.Join(dir, "**", "*.txt"), rmCmd, "bar.txt")
+	output, err := ExecCmd(NewCommand(), "run", "--git-diff=main .", filepath.Join(dir, "**", "*.txt"), rmCmd, "bar.txt")
 	if err != nil {
 		t.Errorf("btlr run failed: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestMaxCmdDur(t *testing.T) {
 		sleepCmd = "sleep 2"
 	}
 
-	output, err := ExecCmd(rootCmd, "run", "--max-cmd-duration=1s", filepath.Join(dir, "**", "*.txt"), sleepCmd)
+	output, err := ExecCmd(NewCommand(), "run", "--max-cmd-duration=1s", filepath.Join(dir, "**", "*.txt"), sleepCmd)
 	if err != nil {
 		var eErr *exitError
 		if !errors.As(err, &eErr) || eErr.Code != 2 {


### PR DESCRIPTION
Refactors the global commands into individual commands. This eliminates some race conditions when the command is reused in the tests.