### PR TITLE
chore: disable windows tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         goarch: ["", "386"]
         exclude: 
           - os: macos-latest


### PR DESCRIPTION
This disables the windows tests. The binary doesn't fully work on windows as-is, which wasn't caught because only tested on linux and mac. 